### PR TITLE
Mark diagram pages as transclusion for display_diagram parser function

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -259,5 +259,8 @@
 			"description": "Whether to render Drawio diagrams directly as <svg> elements instead of <img> elements."
 		}
 	},
+	"ConfigRegistry": {
+		"flexdiagrams": "GlobalVarConfig::newInstance"
+	},
 	"manifest_version": 2
 }

--- a/includes/FD_DisplayDiagram.php
+++ b/includes/FD_DisplayDiagram.php
@@ -8,13 +8,18 @@
 
 use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Title\Title;
+use MediaWiki\Content\TextContent;
 
 class FDDisplayDiagram {
 
 	/** @var int The number of instances of #display_diagram on this page */
 	private static $numInstances = 0;
+
+	/** @var ?Config */
+	private static $config;
 
 	/**
 	 * Handles the #display_diagram parser function - displays the
@@ -28,7 +33,7 @@ class FDDisplayDiagram {
 		// we already know the $parser...
 		array_shift( $params );
 
-		$parser->getOutput()->updateCacheExpiry( 0 );
+		$parserOutput = $parser->getOutput();
 
 		$diagramPageName = $params[0];
 
@@ -37,66 +42,103 @@ class FDDisplayDiagram {
 			return '<div class="error">' . "Page [[$diagramPage]] does not exist." . '</div>';
 		}
 
-		if ( $diagramPage->getNamespace() == FD_NS_BPMN || $diagramPage->getNamespace() == FD_NS_GANTT ) {
+		$revRecord = self::getDiagramPageRevisionRecord( $diagramPage );
+		if ( $revRecord === null ) {
+			return '<div class="error">' . "Page [[$diagramPage]] does not have a revision." . '</div>';
+		}
+
+		// Register the diagram page as a tranclusion
+		$parserOutput->addTemplate(
+			$diagramPage,
+			$revRecord->getPageId(),
+			$revRecord->getId()
+		);
+
+		$diagramType = $diagramPage->getNamespace();
+
+		if ( $diagramType == FD_NS_BPMN || $diagramType == FD_NS_GANTT ) {
 			if ( self::$numInstances++ > 0 ) {
 				return '<div class="error">Due to current limitations, #display_diagram can only ' .
 					'be called once per page on any BPMN or Gantt diagram.</div>';
 			}
 		}
 
-		if ( $diagramPage->getNamespace() == FD_NS_BPMN ) {
-			global $wgOut;
-			$wgOut->addModules( 'ext.flexdiagrams.bpmn.viewer' );
-			$text = Html::element( 'div', [
-				'id' => 'canvas',
-				'data-wiki-page' => $diagramPageName
-			], ' ' );
-		} elseif ( $diagramPage->getNamespace() == FD_NS_GANTT ) {
-			global $wgOut;
-			$wgOut->addModules( 'ext.flexdiagrams.gantt' );
-			$text = Html::element( 'div', [
-				'id' => 'canvas',
-				'data-wiki-page' => $diagramPageName
-			], ' ' );
-		} elseif ( $diagramPage->getNamespace() == FD_NS_DRAWIO ) {
-			global $wgOut;
-			$wgOut->addModules( 'ext.flexdiagrams.drawio' );
-			$text = Html::element( 'figure', [
-				'class' => 'ext-flexdiagrams-diagram-container',
-				'data-mw-flexdiagrams-type' => 'drawio',
-				'data-mw-flexdiagrams-page' => $diagramPageName,
-				'data-mw-flexdiagrams-svg' => $wgOut->getConfig()->get(
-					'FlexDiagramsDrawioRenderSVG' ) ? 'true' : 'false',
-			], ' ' );
-		} elseif ( $diagramPage->getNamespace() == FD_NS_DOT ) {
-			global $wgOut, $wgResourceLoaderDebug;
-			$wgResourceLoaderDebug = true;
-			$wgOut->addModules( 'ext.flexdiagrams.dot' );
-			$revisionRecord = MediaWikiServices::getInstance()
-				->getRevisionLookup()
-				->getRevisionByTitle( $diagramPage );
-			$dotText = $revisionRecord->getContent( SlotRecord::MAIN )->getText();
-			$text = Html::rawElement( 'div', [
-				'class' => 'dotText'
-			], "<nowiki>$dotText</nowiki>" );
-			return [ $text, 'noparse' => false, 'isHTML' => false ];
-		} elseif ( $diagramPage->getNamespace() == FD_NS_MERMAID ) {
-			global $wgOut, $wgResourceLoaderDebug;
-			$wgResourceLoaderDebug = true;
-			$wgOut->addModules( 'ext.flexdiagrams.mermaid' );
-			$revisionRecord = MediaWikiServices::getInstance()
-				->getRevisionLookup()
-				->getRevisionByTitle( $diagramPage );
-			$mermaidText = $revisionRecord->getContent( SlotRecord::MAIN )->getText();
-			$text = Html::rawElement( 'div', [
-				'class' => 'mermaid'
-			], "<nowiki>$mermaidText</nowiki>" );
-			return [ $text, 'noparse' => false, 'isHTML' => false ];
-		} else {
-			$text = '<div class="error">Invalid namespace for a diagram page.</div>';
+		switch ( $diagramType ) {
+			case FD_NS_BPMN:
+				$parserOutput->addModules( [ 'ext.flexdiagrams.bpmn.viewer' ] );
+				$text = Html::element( 'div', [
+					'id' => 'canvas',
+					'data-wiki-page' => $diagramPageName
+				], ' ' );
+				break;
+			case FD_NS_GANTT:
+				$parserOutput->addModules( [ 'ext.flexdiagrams.gantt' ] );
+				$text = Html::element( 'div', [
+					'id' => 'canvas',
+					'data-wiki-page' => $diagramPageName
+				], ' ' );
+				break;
+			case FD_NS_DRAWIO:
+				$parserOutput->addModules( [ 'ext.flexdiagrams.drawio' ] );
+				$renderSVG = self::getConfig()
+					->get( 'FlexDiagramsDrawioRenderSVG' ) ? 'true' : 'false';
+				$text = Html::element( 'figure', [
+					'class' => 'ext-flexdiagrams-diagram-container',
+					'data-mw-flexdiagrams-type' => 'drawio',
+					'data-mw-flexdiagrams-page' => $diagramPageName,
+					'data-mw-flexdiagrams-svg' => $renderSVG,
+				], ' ' );
+				break;
+			case FD_NS_DOT:
+				global $wgResourceLoaderDebug;
+				$wgResourceLoaderDebug = true;
+				$parserOutput->updateCacheExpiry( 0 );
+				$parserOutput->addModules( [ 'ext.flexdiagrams.dot' ] );
+				$dotText = self::getDiagramPageContentText( $revRecord );
+				$text = Html::rawElement( 'div', [
+					'class' => 'dotText'
+				], "<nowiki>$dotText</nowiki>" );
+				return [ $text, 'noparse' => false, 'isHTML' => false ];
+			case FD_NS_MERMAID:
+				global $wgResourceLoaderDebug;
+				$wgResourceLoaderDebug = true;
+				$parserOutput->updateCacheExpiry( 0 );
+				$parserOutput->addModules( [ 'ext.flexdiagrams.mermaid' ] );
+				$mermaidText = self::getDiagramPageContentText( $revRecord );
+				$text = Html::rawElement( 'div', [
+					'class' => 'mermaid'
+				], "<nowiki>$mermaidText</nowiki>" );
+				return [ $text, 'noparse' => false, 'isHTML' => false ];
+			default:
+				$text = '<div class="error">Invalid namespace for a diagram page.</div>';
 		}
 
 		return [ $text, 'noparse' => true, 'isHTML' => true ];
 	}
 
+	/**
+	 * @return Config
+	 */
+	private static function getConfig() {
+		if ( self::$config === null ) {
+			self::$config = MediaWikiServices::getInstance()
+				->getConfigFactory()
+				->makeConfig( 'flexdiagrams' );
+		}
+		return self::$config;
+	}
+
+	private static function getDiagramPageRevisionRecord( Title $diagramPage ): ?RevisionRecord {
+		return MediaWikiServices::getInstance()
+			->getRevisionLookup()
+			->getRevisionByTitle( $diagramPage );
+	}
+
+	private static function getDiagramPageContentText( RevisionRecord $revRecord ): string {
+		$content = $revRecord->getContent( SlotRecord::MAIN );
+		if ( $content instanceof TextContent ) {
+			return $content->getText();
+		}
+		return '';
+	}
 }


### PR DESCRIPTION
Since diagram pages are technically transcluded into the page, it is helpful to mark them as transclusion to populate the Special:WhatLinksHere list on the diagram page.

Also minor cleanups and refactor to the FDDisplayDiagram for maintainability.